### PR TITLE
Derive `Hash` on `PackageEcosystem`

### DIFF
--- a/src/v2.rs
+++ b/src/v2.rs
@@ -186,7 +186,7 @@ impl Update {
 /// See [GitHub Docs][docs] for more.
 ///
 /// [docs]: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#package-ecosystem
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum PackageEcosystem {


### PR DESCRIPTION
Hey, thanks for making this! I'm currently trying to use it for something and I'd benefit from `PackageEcosystem` being hashable (to use it as a key in a `HashSet` or `HashMap`, for instance).

I'm a Rust noob, so I hope I've not missed something obvious.

Let me know what you think!