### PR TITLE
chore(v2): add missing ecosystems

### DIFF
--- a/.github/.cspell/project-dictionary.txt
+++ b/.github/.cspell/project-dictionary.txt
@@ -1,4 +1,5 @@
 automerged
+devcontainers
 gitsubmodule
 gomod
 hashbrown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Add `v2::PackageEcosystem::{Bun,Devcontainers,DockerCompose,DotnetSdk,Helm,Uv}` variants.
+
 - Add `v2::Update::directories` field.
 
 - Make `v2::Update::directory` field optional to reflect upstream change due to addition of `v2::Update::directories`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Renamed `v2::PackageEcosystem::Hex` to `v2::PackageEcosystem::Mix` (Hex is the package manager).
+
 - Add `v2::PackageEcosystem::{Bun,Devcontainers,DockerCompose,DotnetSdk,Helm,Uv}` variants.
 
 - Add `v2::Update::directories` field.

--- a/src/gen/display.rs
+++ b/src/gen/display.rs
@@ -99,7 +99,7 @@ impl fmt::Display for crate::v2::PackageEcosystem {
             Self::Docker => f.write_str("docker"),
             Self::DockerCompose => f.write_str("docker-compose"),
             Self::DotnetSdk => f.write_str("dotnet-sdk"),
-            Self::Hex => f.write_str("hex"),
+            Self::Mix => f.write_str("mix"),
             Self::Helm => f.write_str("helm"),
             Self::Elm => f.write_str("elm"),
             Self::Gitsubmodule => f.write_str("gitsubmodule"),

--- a/src/gen/display.rs
+++ b/src/gen/display.rs
@@ -91,11 +91,16 @@ impl fmt::Display for crate::v1::VersionRequirementUpdate {
 impl fmt::Display for crate::v2::PackageEcosystem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Bun => f.write_str("bun"),
             Self::Bundler => f.write_str("bundler"),
             Self::Cargo => f.write_str("cargo"),
             Self::Composer => f.write_str("composer"),
+            Self::Devcontainers => f.write_str("devcontainers"),
             Self::Docker => f.write_str("docker"),
+            Self::DockerCompose => f.write_str("docker-compose"),
+            Self::DotnetSdk => f.write_str("dotnet-sdk"),
             Self::Hex => f.write_str("hex"),
+            Self::Helm => f.write_str("helm"),
             Self::Elm => f.write_str("elm"),
             Self::Gitsubmodule => f.write_str("gitsubmodule"),
             Self::GithubActions => f.write_str("github-actions"),
@@ -108,6 +113,7 @@ impl fmt::Display for crate::v2::PackageEcosystem {
             Self::Pub => f.write_str("pub"),
             Self::Swift => f.write_str("swift"),
             Self::Terraform => f.write_str("terraform"),
+            Self::Uv => f.write_str("uv"),
         }
     }
 }

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -215,21 +215,31 @@ impl Update {
 ///
 /// See [GitHub Docs][docs] for more.
 ///
-/// [docs]: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#package-ecosystem
+/// [docs]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum PackageEcosystem {
+    /// `bun`
+    Bun,
     /// `bundler`
     Bundler,
     /// `cargo`
     Cargo,
     /// `composer`
     Composer,
+    /// `devcontainers`
+    Devcontainers,
     /// `docker`
     Docker,
-    /// `hex`
+    /// `docker-compose`
+    DockerCompose,
+    /// `dotnet-sdk`
+    DotnetSdk,
+    /// `mix`
     Hex,
+    /// `helm`
+    Helm,
     /// `elm`
     Elm,
     /// `gitsubmodule`
@@ -254,6 +264,8 @@ pub enum PackageEcosystem {
     Swift,
     /// `terraform`
     Terraform,
+    /// `uv`
+    Uv,
 }
 
 /// How often to check for updates.

--- a/src/v2.rs
+++ b/src/v2.rs
@@ -236,8 +236,8 @@ pub enum PackageEcosystem {
     DockerCompose,
     /// `dotnet-sdk`
     DotnetSdk,
-    /// `mix`
-    Hex,
+    /// `mix` (package manager "Hex")
+    Mix,
     /// `helm`
     Helm,
     /// `elm`

--- a/tests/fixtures/v2.yml
+++ b/tests/fixtures/v2.yml
@@ -4,6 +4,10 @@
 version: 2
 enable-beta-ecosystems: true
 updates:
+  - package-ecosystem: 'bun'
+    directory: '/'
+    schedule:
+      interval: 'daily'
   - package-ecosystem: 'bundler'
     directory: '/'
     schedule:
@@ -16,7 +20,23 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+  - package-ecosystem: 'devcontainers'
+    directory: '/'
+    schedule:
+      interval: 'daily'
   - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'docker-compose'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'dotnet-sdk'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'helm'
     directory: '/'
     schedule:
       interval: 'daily'
@@ -69,6 +89,10 @@ updates:
     schedule:
       interval: 'daily'
   - package-ecosystem: 'terraform'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'uv'
     directory: '/'
     schedule:
       interval: 'daily'

--- a/tests/fixtures/v2.yml
+++ b/tests/fixtures/v2.yml
@@ -40,7 +40,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-  - package-ecosystem: 'hex'
+  - package-ecosystem: 'mix' # for package manager "Hex"
     directory: '/'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
### Added missing v2 ecosystems
- bun
- devcontainers
- docker-compose
- dotnet-sdk
- helm
- uv

### TODO
- Clarify or rename that `PackageEcosystem::Hex` has the YAML value `mix` (displayed is `hex` at the moment which is the name of the package manager)
- Maybe document that a single YAML value can stand for multiple package managers (i.e. `pip` and `npm`)

Fixes #14
